### PR TITLE
Support for filtering rows

### DIFF
--- a/src/DayleRees/ContainerDebug/Command.php
+++ b/src/DayleRees/ContainerDebug/Command.php
@@ -217,7 +217,7 @@ class Command extends IlluminateCommand
     protected function getArguments()
     {
         return array(
-            array('prefix', InputArgument::OPTIONAL, 'Only list classes with have a certain prefix.', ''),
+            array('prefix', InputArgument::OPTIONAL, 'Only list services which have a certain prefix.', ''),
         );
     }
 }

--- a/src/DayleRees/ContainerDebug/Command.php
+++ b/src/DayleRees/ContainerDebug/Command.php
@@ -99,21 +99,37 @@ class Command extends IlluminateCommand
      */
     public function buildTableRows($services)
     {
+        $prefix = $this->argument('prefix');
+
         $rows = array();
-        foreach (array_keys($services) as $identifier) {
-            try {
-                $service = $this->resolveService($identifier);
-                $rows[] = array(
-                    $identifier,
-                    $this->getServiceDescription($service),
-                    $this->calculateServiceResolutionTime($identifier)
-                );
-            }
-            catch (Exception $e) {
-                $rows[] = array($identifier, 'Unable to resolve service.', 'N/A');
+        foreach ($services as $identifier) {
+            if (empty($prefix) || strpos($identifier, $prefix) === 0)
+            {
+                $rows[] = $this->buildServiceRow($identifier);
             }
         }
         return $rows;
+    }
+
+    /**
+     * Builds a row for the service with the given identifier.
+     *
+     * @param  string $identifier
+     * @return array
+     */
+    public function buildServiceRow($identifier)
+    {
+        try {
+            $service = $this->resolveService($identifier);
+            return array(
+                $identifier,
+                $this->getServiceDescription($service),
+                $this->calculateServiceResolutionTime($identifier)
+            );
+        }
+        catch (Exception $e) {
+            return array($identifier, 'Unable to resolve service.', 'N/A');
+        }
     }
 
     /**
@@ -123,8 +139,8 @@ class Command extends IlluminateCommand
      */
     public function getContainerBindings()
     {
-        $bindings = $this->laravel->getBindings();
-        ksort($bindings);
+        $bindings = array_keys($this->laravel->getBindings());
+        sort($bindings);
         return $bindings;
     }
 
@@ -191,5 +207,17 @@ class Command extends IlluminateCommand
     public function serviceIsObject($service)
     {
         return gettype($service) === 'object';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return array(
+            array('prefix', InputArgument::OPTIONAL, 'Only list classes with have a certain prefix.', ''),
+        );
     }
 }


### PR DESCRIPTION
Hi there Dayle,

I thought it would be useful to filter the table, so this PR adds an optional argument which can be used to specify the prefix of the services to show.

I also rewrote many tests, moving initialisation to `setUp` and relying on an actual Container instance.
