### PR TITLE
Laravel 5.4/5.5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,17 @@
         }
     ],
     "require": {
-        "illuminate/container": "4.*",
-        "illuminate/console": "4.*"
+        "illuminate/container": "5.*",
+        "illuminate/console": "5.*",
+        "symfony/psr-http-message-bridge": "^0.2",
+        "zendframework/zend-diactoros": "*",
+        "league/flysystem-aws-s3-v3": "*",
+        "predis/predis": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "mockery/mockery": "0.8.*",
-        "symfony/event-dispatcher": "2.3.*"
+        "phpunit/phpunit": "~5.7",
+        "mockery/mockery": "0.9.*",
+        "symfony/event-dispatcher": "~2.8|~3.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,13 @@
             "homepage": "http://daylerees.com"
         }
     ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "DayleRees\\ContainerDebug\\ServiceProvider"
+            ]
+        }
+    },
     "require": {
         "illuminate/container": "5.*",
         "illuminate/console": "5.*",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The container debug command can be used to inspect the Laravel four service cont
 
 Add the following dependency to your Laravel project:
 
-    "daylerees/container-debug": "4.0.*"
+    "daylerees/container-debug": "5.0.x-dev"
 
 Now run...
 
@@ -26,6 +26,12 @@ to download the package. Now add the service provider to your project configurat
     ),
 
 Now you can execute the command using the Artisan CLI tool.
+
+Caveat: if your app defines more services beyond the framework default and its 
+own, be sure to also require them using composer, as they will need to be 
+resolved in order to be enumerated by this command. Otherwise you are likely to 
+encounter `Class not found` errors from the autoloader.
+
 
 ## Usage
 

--- a/src/DayleRees/ContainerDebug/Command.php
+++ b/src/DayleRees/ContainerDebug/Command.php
@@ -5,8 +5,8 @@ namespace DayleRees\ContainerDebug;
 use Exception;
 use Illuminate\Console\Application;
 use Illuminate\Container\Container;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Helper\TableHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Console\Command as IlluminateCommand;
 
@@ -67,11 +67,11 @@ class Command extends IlluminateCommand
      * Construct an ASCII table to display services.
      *
      * @param  array $services
-     * @return TableHelper
+     * @return \Symfony\Component\Console\Helper\Table
      */
     public function buildServiceTable($services)
     {
-        $table = new TableHelper;
+        $table = new Table($this->getOutput());
         $table->setHeaders($this->buildTableHeaders());
         $table->setRows($this->buildTableRows($services));
         return $table;

--- a/src/DayleRees/ContainerDebug/Command.php
+++ b/src/DayleRees/ContainerDebug/Command.php
@@ -52,11 +52,21 @@ class Command extends IlluminateCommand
     protected $description = 'View the contents of the IoC container.';
 
     /**
-     * Execute the command.
+     * Execute the command (pre-5.5).
      *
      * @return void
      */
     public function fire()
+    {
+        $this->handle();
+    }
+
+    /**
+     * Execute the command (5.5).
+     *
+     * @return void
+     */
+    public function handle()
     {
         $services = $this->getContainerBindings();
         $table = $this->buildServiceTable($services);


### PR DESCRIPTION
- Implement the 5.5-new handle() vs fire() command method.
- Add the 5.5-new extra/laravel section in composer.json.
- Implement the provides() method on the service provider.
- Require the PSR7 message bridge to include Diactoros needed by RoutingServiceProvider.
- Require a few dependencies needed by the default Laravel project configuration.
- Might need to go into a separate branch in case it breaks Laravel 4 projects